### PR TITLE
Add rotating cat mascot scenes with jokes

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
         <footer class="footer">
             <p>File cheker © 2024 by Liza. Работает прямо в браузере, данные не покидают ваш компьютер.</p>
         </footer>
+        <div id="cat-mascot-root" class="cat-mascot-root" aria-live="polite"></div>
     </div>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,113 @@ const TABLE_FORMATS = {
     xls: { label: 'Excel 97-2003 (.xls)', extensions: ['.xls'], accept: '.xls', reader: readExcelFile }
 };
 
+const CAT_SCENES = [
+    {
+        id: 'keyboard-nap',
+        ariaLabel: 'Черный кот растянулся на клавиатуре и зевает.',
+        svg: `
+            <svg viewBox="0 0 180 120" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <linearGradient id="furGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+                        <stop offset="0%" stop-color="#1b1b1f" />
+                        <stop offset="100%" stop-color="#09090c" />
+                    </linearGradient>
+                </defs>
+                <rect x="20" y="78" width="140" height="18" rx="8" fill="#2f3545" />
+                <rect x="12" y="92" width="156" height="16" rx="6" fill="#252a38" />
+                <ellipse cx="70" cy="62" rx="52" ry="28" fill="url(#furGradient)" />
+                <ellipse cx="126" cy="58" rx="34" ry="22" fill="url(#furGradient)" />
+                <circle cx="136" cy="36" r="18" fill="url(#furGradient)" />
+                <path d="M146 35 Q150 32 154 36" stroke="#f4f4f6" stroke-width="2" stroke-linecap="round" />
+                <circle cx="132" cy="33" r="3" fill="#f4f4f6" />
+                <circle cx="142" cy="35" r="3" fill="#f4f4f6" />
+                <path d="M138 43 Q140 46 144 44" stroke="#f4f4f6" stroke-width="1.6" stroke-linecap="round" />
+                <path d="M40 66 Q34 74 26 70" stroke="#f4f4f6" stroke-width="2" stroke-linecap="round" />
+            </svg>
+        `,
+        message: 'Лиза выгрузила новый датасет, Руслан чинит код, а я проверяю, чтобы клавиатура оставалась тёплой.',
+        positionClass: 'cat-mascot--top-right cat-mascot--mirrored'
+    },
+    {
+        id: 'coffee-cup',
+        ariaLabel: 'Черный кот обнял кружку с кофе и прищурился.',
+        svg: `
+            <svg viewBox="0 0 180 140" xmlns="http://www.w3.org/2000/svg">
+                <ellipse cx="96" cy="96" rx="62" ry="32" fill="#101117" />
+                <ellipse cx="96" cy="74" rx="54" ry="28" fill="#18181f" />
+                <ellipse cx="62" cy="60" rx="28" ry="26" fill="#18181f" />
+                <ellipse cx="126" cy="60" rx="28" ry="26" fill="#18181f" />
+                <circle cx="72" cy="54" r="6" fill="#f4f4f6" />
+                <circle cx="120" cy="54" r="6" fill="#f4f4f6" />
+                <path d="M80 60 Q90 70 100 60" stroke="#f4f4f6" stroke-width="3" stroke-linecap="round" />
+                <rect x="110" y="78" width="44" height="32" rx="12" fill="#3c2f23" />
+                <ellipse cx="132" cy="76" rx="28" ry="12" fill="#4e3d2c" />
+                <ellipse cx="132" cy="76" rx="18" ry="6" fill="#8c5a3c" />
+                <path d="M150 82 Q164 86 162 102" stroke="#3c2f23" stroke-width="8" stroke-linecap="round" />
+            </svg>
+        `,
+        message: 'Руслан бодрит себя кофе, Лиза — свежим отчётом. А мне бы бодрящий корм, но никто не заметил пустую миску.',
+        positionClass: 'cat-mascot--middle-left'
+    },
+    {
+        id: 'blanket-roll',
+        ariaLabel: 'Черный кот свернулся в клубок на пледе.',
+        svg: `
+            <svg viewBox="0 0 180 140" xmlns="http://www.w3.org/2000/svg">
+                <rect x="26" y="40" width="128" height="80" rx="28" fill="#1d1f2b" />
+                <ellipse cx="90" cy="88" rx="58" ry="34" fill="#111118" />
+                <ellipse cx="120" cy="64" rx="30" ry="26" fill="#111118" />
+                <ellipse cx="62" cy="64" rx="30" ry="26" fill="#111118" />
+                <circle cx="70" cy="58" r="5" fill="#f5f5f7" />
+                <circle cx="110" cy="58" r="5" fill="#f5f5f7" />
+                <path d="M74 66 Q86 74 102 66" stroke="#f5f5f7" stroke-width="2.6" stroke-linecap="round" />
+                <path d="M46 108 Q60 118 72 110" stroke="#f5f5f7" stroke-width="2" stroke-linecap="round" />
+            </svg>
+        `,
+        message: 'Лиза строит дашборды, Руслан деплоит, а я тестирую новый плед на совместимость с ленивой жизнью.',
+        positionClass: 'cat-mascot--bottom-right cat-mascot--mirrored'
+    },
+    {
+        id: 'monitor-guard',
+        ariaLabel: 'Черный кот сидит перед монитором и смотрит строго.',
+        svg: `
+            <svg viewBox="0 0 180 150" xmlns="http://www.w3.org/2000/svg">
+                <rect x="52" y="20" width="84" height="58" rx="10" fill="#222838" />
+                <rect x="74" y="78" width="40" height="10" rx="4" fill="#181c29" />
+                <rect x="64" y="88" width="60" height="10" rx="6" fill="#101117" />
+                <ellipse cx="92" cy="108" rx="54" ry="32" fill="#0f1118" />
+                <ellipse cx="66" cy="84" rx="24" ry="22" fill="#0f1118" />
+                <ellipse cx="118" cy="84" rx="24" ry="22" fill="#0f1118" />
+                <circle cx="78" cy="80" r="6" fill="#f4f4f6" />
+                <circle cx="108" cy="80" r="6" fill="#f4f4f6" />
+                <path d="M84 92 Q92 96 100 92" stroke="#f4f4f6" stroke-width="2.4" stroke-linecap="round" />
+                <path d="M56 120 Q60 132 52 138" stroke="#f4f4f6" stroke-width="2" stroke-linecap="round" />
+            </svg>
+        `,
+        message: 'Следующий, кто потревожит мой монитор, будет слушать лекцию о чистом коде от Руслана и о чистом датасете от Лизы.',
+        positionClass: 'cat-mascot--top-left'
+    },
+    {
+        id: 'yarn-plan',
+        ariaLabel: 'Черный кот играет с клубком пряжи и хитро улыбается.',
+        svg: `
+            <svg viewBox="0 0 180 150" xmlns="http://www.w3.org/2000/svg">
+                <ellipse cx="92" cy="94" rx="58" ry="34" fill="#12141d" />
+                <ellipse cx="60" cy="74" rx="28" ry="26" fill="#12141d" />
+                <ellipse cx="122" cy="74" rx="28" ry="26" fill="#12141d" />
+                <circle cx="70" cy="68" r="6" fill="#f4f4f6" />
+                <circle cx="112" cy="68" r="6" fill="#f4f4f6" />
+                <path d="M78 76 Q92 84 108 76" stroke="#f4f4f6" stroke-width="2.4" stroke-linecap="round" />
+                <circle cx="126" cy="110" r="18" fill="#f59e0b" />
+                <path d="M112 104 Q130 118 144 96" stroke="#f59e0b" stroke-width="4" fill="none" stroke-linecap="round" />
+                <path d="M144 96 Q152 106 138 118" stroke="#f59e0b" stroke-width="4" fill="none" stroke-linecap="round" />
+            </svg>
+        `,
+        message: 'Лиза ловит аномалии в данных, Руслан — баги в коде, а я ловлю клубок и прячу его в продакшене.',
+        positionClass: 'cat-mascot--middle-right cat-mascot--mirrored'
+    }
+];
+
 const form = document.getElementById('compare-form');
 const fileInputA = document.getElementById('fileA');
 const fileInputB = document.getElementById('fileB');
@@ -28,6 +135,7 @@ let lastFileNameB = '';
 let lastKeyFieldName = '';
 
 initializeFormatHandling();
+initializeCatMascot();
 
 function validateFormInput(fileA, fileB, keyField, format) {
     const formatConfig = TABLE_FORMATS[format];
@@ -208,6 +316,33 @@ function readExcelFile(file) {
         };
         reader.readAsArrayBuffer(file);
     });
+}
+
+function initializeCatMascot() {
+    const root = document.getElementById('cat-mascot-root');
+    if (!root || !CAT_SCENES.length) {
+        return;
+    }
+
+    const sceneIndex = Math.floor(Math.random() * CAT_SCENES.length);
+    const scene = CAT_SCENES[sceneIndex];
+
+    const wrapper = document.createElement('div');
+    wrapper.className = `cat-mascot ${scene.positionClass}`.trim();
+
+    const imageContainer = document.createElement('div');
+    imageContainer.className = 'cat-mascot__image';
+    imageContainer.setAttribute('role', 'img');
+    imageContainer.setAttribute('aria-label', scene.ariaLabel);
+    imageContainer.innerHTML = scene.svg;
+
+    const bubble = document.createElement('div');
+    bubble.className = 'cat-mascot__bubble';
+    bubble.textContent = scene.message;
+
+    wrapper.append(imageContainer, bubble);
+    root.innerHTML = '';
+    root.append(wrapper);
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -29,6 +29,122 @@ body {
     min-height: 100vh;
     display: flex;
     flex-direction: column;
+    position: relative;
+}
+
+.cat-mascot-root {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.cat-mascot {
+    position: absolute;
+    display: flex;
+    align-items: flex-end;
+    gap: 16px;
+    max-width: min(320px, 80vw);
+    pointer-events: none;
+    z-index: 3;
+}
+
+.cat-mascot__image {
+    width: 140px;
+    flex-shrink: 0;
+    filter: drop-shadow(0 8px 16px rgba(15, 23, 42, 0.12));
+}
+
+.cat-mascot__image svg {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.cat-mascot__bubble {
+    padding: 14px 18px;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.86);
+    color: #f9faff;
+    font-size: 14px;
+    line-height: 1.4;
+    position: relative;
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
+}
+
+.cat-mascot__bubble::after {
+    content: '';
+    position: absolute;
+    bottom: 6px;
+    left: -12px;
+    width: 0;
+    height: 0;
+    border: 10px solid transparent;
+    border-right-color: rgba(15, 23, 42, 0.86);
+}
+
+.cat-mascot--mirrored {
+    flex-direction: row-reverse;
+}
+
+.cat-mascot--mirrored .cat-mascot__bubble::after {
+    left: auto;
+    right: -12px;
+    border-right-color: transparent;
+    border-left-color: rgba(15, 23, 42, 0.86);
+}
+
+.cat-mascot--top-left {
+    top: 32px;
+    left: 24px;
+}
+
+.cat-mascot--top-right {
+    top: 48px;
+    right: 32px;
+}
+
+.cat-mascot--middle-left {
+    top: 46%;
+    left: 40px;
+}
+
+.cat-mascot--middle-right {
+    top: 52%;
+    right: 40px;
+}
+
+.cat-mascot--bottom-left {
+    bottom: 140px;
+    left: 28px;
+}
+
+.cat-mascot--bottom-right {
+    bottom: 140px;
+    right: 28px;
+}
+
+@media (max-width: 900px) {
+    .cat-mascot {
+        max-width: min(280px, 90vw);
+    }
+
+    .cat-mascot__image {
+        width: 120px;
+    }
+}
+
+@media (max-width: 720px) {
+    .cat-mascot {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%);
+        flex-direction: row;
+    }
+
+    .cat-mascot__bubble::after {
+        display: none;
+    }
 }
 
 .hero {


### PR DESCRIPTION
## Summary
- add a root container to host the roaming cat mascot
- style the mascot, speech bubble, and multiple placement options with responsive tweaks
- inject rotating SVG cat scenes with jokes about Liza and Ruslan at random positions on each load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc45b74e74832ab2cf708adeb66ff0