### PR TITLE
Harden security of CSV comparison workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{html,css,js,mjs}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+npm-debug.log*

--- a/index.html
+++ b/index.html
@@ -3,13 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests">
     <title>File cheker — Веб-версия</title>
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js" integrity="sha384-D/t0ZMqQW31H3az8ktEiNb39wyKnS82iFY52QPACM+IjKW3jDUhyIgh2PApRqJZs" crossorigin="anonymous" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js" integrity="sha384-vtjasyidUo0kW94K5MXDXntzOJpQgBKXmE7e2Ga4LG0skTTLeBi97eFAXsqewJjw" crossorigin="anonymous" defer></script>
     <script src="script.js" type="module" defer></script>
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "csv_check_pro",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/script.test.mjs
+++ b/tests/script.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildAggregatedReportData,
+  compareDatasets,
+  convertRowsToCsv,
+  sanitizeFilename,
+  sanitizeRows
+} from '../script.js';
+
+test('compareDatasets detects mismatches and missing records', () => {
+  const datasetA = {
+    rows: [
+      { POLICY_NO: '1', Amount: '100', Status: 'Active' },
+      { POLICY_NO: '2', Amount: '150', Status: 'Pending' }
+    ]
+  };
+  const datasetB = {
+    rows: [
+      { policy_no: '1', Amount: '110', Status: 'Active' },
+      { policy_no: '3', Amount: '200', Status: 'Closed' }
+    ]
+  };
+
+  const result = compareDatasets(datasetA, datasetB, 'POLICY_NO', 'A.csv', 'B.csv');
+  assert.equal(result.differences.length, 3);
+  assert.deepEqual(
+    new Set(result.differences.map((diff) => diff.difference_type)),
+    new Set(['value_mismatch', 'missing_in_a', 'missing_in_b'])
+  );
+  assert.equal(result.headers.key, 'POLICY_NO');
+});
+
+test('buildAggregatedReportData summarizes differences by column', () => {
+  const differences = [
+    { column: 'Amount', difference_type: 'value_mismatch' },
+    { column: 'Amount', difference_type: 'value_mismatch' },
+    { column: '__missing__', difference_type: 'missing_in_a' }
+  ];
+
+  const rows = buildAggregatedReportData(differences);
+  assert.deepEqual(rows[0], [
+    'Поле',
+    'Всего расхождений',
+    'Несовпадений значений',
+    'Отсутствует в файле 1',
+    'Отсутствует в файле 2'
+  ]);
+  assert.deepEqual(rows[1], ['Amount', '2', '2', '0', '0']);
+  assert.deepEqual(rows[2], ['Строка отсутствует', '1', '0', '1', '0']);
+});
+
+test('sanitizeRows drops dangerous prototype pollution keys', () => {
+  const polluted = sanitizeRows([
+    { __proto__: { hacked: true }, ' constructor ': 'oops', Normal: 'value' }
+  ]);
+
+  assert.deepEqual(polluted, [{ Normal: 'value' }]);
+  assert.equal(Object.prototype.hacked, undefined);
+});
+
+test('sanitizeFilename produces safe basename', () => {
+  assert.equal(sanitizeFilename('../../secret.txt'), 'secret.txt');
+  assert.equal(sanitizeFilename(''), 'report');
+});
+
+test('convertRowsToCsv quotes cells with commas and quotes', () => {
+  const csv = convertRowsToCsv([
+    ['Field', 'Value'],
+    ['note', 'needs, quoting'],
+    ['quote', '"hello"']
+  ]);
+
+  assert.equal(
+    csv,
+    'Field,Value\r\nnote,"needs, quoting"\r\nquote,"""hello"""'
+  );
+});


### PR DESCRIPTION
## Summary
- add CSP and SRI checks to external assets and document defaults
- harden dataset sanitization, filename handling, and browser guards for safer comparisons
- add node-based regression tests along with repository editor and ignore configs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd0fbad8ec832aba4a531d5d0a8f2d